### PR TITLE
Vector type refactor

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,6 @@ Created from my boilerplate here: https://github.com/joshua-burbidge/femtovg-wgp
 #### TODO
 - disable/don't render ui after starting to improve performance?
   - don't clear canvas?
-- is growing elliptical orbit accurate or just because of approximation (Vx = 5)
-  - inaccurate
-  - fix that (smaller dt works)
+
+##### Validate
+- energy drift

--- a/src/app/core/physics.rs
+++ b/src/app/core/physics.rs
@@ -35,20 +35,15 @@ impl Vector<Position> {
     }
 
     // position after t seconds given constant acceleration
-    pub fn update(
-        &self,
-        v: &Vector<Velocity>,
-        a: &Vector<Acceleration>,
-        t: f32,
-    ) -> Vector<Position> {
+    pub fn update(&self, v: &Vector<Velocity>, a: &Vector<Acceleration>, t: f32) -> Self {
         // px + vx t + 1/2 ax t^2
-        Vector::<Position>::new(
+        Self::new(
             self.x + v.x * t + 0.5 * a.x * t.powi(2),
             self.y + v.y * t + 0.5 * a.x * t.powi(2),
         )
     }
 
-    pub fn update_const_v(&self, v: &Vector<Velocity>, t: f32) -> Vector<Position> {
+    pub fn update_const_v(&self, v: &Vector<Velocity>, t: f32) -> Self {
         let zero_a = Vector::<Acceleration>::default();
 
         self.update(v, &zero_a, t)
@@ -61,9 +56,9 @@ impl Vector<Velocity> {
     }
 
     // velocity update after t seconds given constant acceleration
-    pub fn update(&self, a: &Vector<Acceleration>, t: f32) -> Vector<Velocity> {
+    pub fn update(&self, a: &Vector<Acceleration>, t: f32) -> Self {
         // vx + ax t
-        Vector::<Velocity>::new(self.x + a.x * t, self.y + a.y * t)
+        Self::new(self.x + a.x * t, self.y + a.y * t)
     }
 }
 

--- a/src/app/core/physics.rs
+++ b/src/app/core/physics.rs
@@ -2,17 +2,20 @@ pub const G: f32 = 6.674e-11; // N m^2 / kg^2
 pub const G_KM: f32 = G * 1e-6; // N km^2 / kg^2 (converted to km)
 
 #[derive(Clone, Debug, Default)]
-pub struct Position;
+pub struct Pos;
 #[derive(Clone, Debug, Default)]
-pub struct Velocity;
+pub struct Vel;
 #[derive(Clone, Debug, Default)]
-pub struct Acceleration;
-// type VecType = Position | Velocity | Acceleration;
+pub struct Acc;
 
 pub trait VectorType {}
-impl VectorType for Position {}
-impl VectorType for Velocity {}
-impl VectorType for Acceleration {}
+impl VectorType for Pos {}
+impl VectorType for Vel {}
+impl VectorType for Acc {}
+
+pub type Position = Vector<Pos>;
+pub type Velocity = Vector<Vel>;
+pub type Acceleration = Vector<Acc>;
 
 #[derive(Clone, Debug, Default)]
 pub struct Vector<T: VectorType> {
@@ -20,9 +23,6 @@ pub struct Vector<T: VectorType> {
     pub x: f32,
     pub y: f32,
 }
-
-// TODO do this
-// pub type P = Vector<Position>;
 
 impl<T: VectorType> Vector<T> {
     pub fn mag(&self) -> f32 {
@@ -37,13 +37,13 @@ impl<T: VectorType> Vector<T> {
     }
 }
 
-impl Vector<Position> {
+impl Vector<Pos> {
     pub fn new(x: f32, y: f32) -> Self {
-        Vector::new_vec(Position, x, y)
+        Vector::new_vec(Pos, x, y)
     }
 
     // position after t seconds given constant acceleration
-    pub fn update(&self, v: &Vector<Velocity>, a: &Vector<Acceleration>, t: f32) -> Self {
+    pub fn update(&self, v: &Velocity, a: &Acceleration, t: f32) -> Self {
         // px + vx t + 1/2 ax t^2
         Self::new(
             self.x + v.x * t + 0.5 * a.x * t.powi(2),
@@ -51,27 +51,27 @@ impl Vector<Position> {
         )
     }
 
-    pub fn update_const_v(&self, v: &Vector<Velocity>, t: f32) -> Self {
-        let zero_a = Vector::<Acceleration>::default();
+    pub fn update_const_v(&self, v: &Velocity, t: f32) -> Self {
+        let zero_a = Acceleration::default();
 
         self.update(v, &zero_a, t)
     }
 }
 
-impl Vector<Velocity> {
+impl Vector<Vel> {
     pub fn new(x: f32, y: f32) -> Self {
-        Vector::new_vec(Velocity, x, y)
+        Vector::new_vec(Vel, x, y)
     }
 
     // velocity update after t seconds given constant acceleration
-    pub fn update(&self, a: &Vector<Acceleration>, t: f32) -> Self {
+    pub fn update(&self, a: &Acceleration, t: f32) -> Self {
         // vx + ax t
         Self::new(self.x + a.x * t, self.y + a.y * t)
     }
 }
 
-impl Vector<Acceleration> {
+impl Vector<Acc> {
     pub fn new(x: f32, y: f32) -> Self {
-        Vector::new_vec(Acceleration, x, y)
+        Vector::new_vec(Acc, x, y)
     }
 }

--- a/src/app/core/physics.rs
+++ b/src/app/core/physics.rs
@@ -1,57 +1,68 @@
 pub const G: f32 = 6.674e-11; // N m^2 / kg^2
 pub const G_KM: f32 = G * 1e-6; // N km^2 / kg^2 (converted to km)
 
-pub trait Vector {
-    fn mag(&self) -> f32;
-}
+#[derive(Clone, Debug, Default)]
+pub struct Position;
+#[derive(Clone, Debug, Default)]
+pub struct Velocity;
+#[derive(Clone, Debug, Default)]
+pub struct Acceleration;
+// type VecType = Position | Velocity | Acceleration;
 
 #[derive(Clone, Debug, Default)]
-pub struct Position {
+pub struct Vector<T> {
+    vec_type: T,
     pub x: f32,
     pub y: f32,
 }
-impl Position {
+// TODO define trait VectorType, then do <T: VectorType> to restrict <T> to be only the valid vector types
+
+// TODO do this
+// pub type P = Vector<Position>;
+
+impl<T> Vector<T> {
+    pub fn mag(&self) -> f32 {
+        (self.x.powi(2) + self.y.powi(2)).sqrt()
+    }
+    fn new_vec(vec_type: T, x: f32, y: f32) -> Self {
+        Self { vec_type, x, y }
+    }
+}
+
+impl Vector<Position> {
     pub fn new(x: f32, y: f32) -> Self {
-        Position { x, y }
+        Vector::new_vec(Position, x, y)
+    }
+
+    // position after t seconds given constant acceleration
+    pub fn update(
+        self,
+        v: &Vector<Velocity>,
+        a: &Vector<Acceleration>,
+        t: f32,
+    ) -> Vector<Position> {
+        // px + vx t + 1/2 ax t^2
+        Vector::<Position>::new(
+            self.x + v.x * t + 0.5 * a.x * t.powi(2),
+            self.y + v.y * t + 0.5 * a.x * t.powi(2),
+        )
     }
 }
 
-// this should just be the type
-impl Vector for Position {
-    fn mag(&self) -> f32 {
-        (self.x.powi(2) + self.y.powi(2)).sqrt()
+impl Vector<Velocity> {
+    pub fn new(x: f32, y: f32) -> Self {
+        Vector::new_vec(Velocity, x, y)
     }
-}
-impl Vector for Velocity {
-    fn mag(&self) -> f32 {
-        (self.x.powi(2) + self.y.powi(2)).sqrt()
-    }
-}
 
-#[derive(Clone, Debug, Default)]
-pub struct Velocity {
-    pub x: f32,
-    pub y: f32,
-}
-#[derive(Clone, Debug, Default)]
-pub struct Acceleration {
-    pub x: f32,
-    pub y: f32,
-}
-
-// position after one tick given constant acceleration
-pub fn new_position(p: &Position, v: &Velocity, a: &Acceleration, t: f32) -> Position {
-    // px + vx t + 1/2 ax t^2
-    Position {
-        x: p.x + v.x * t + 0.5 * a.x * t.powi(2),
-        y: p.y + v.y * t + 0.5 * a.x * t.powi(2),
+    // velocity update after t seconds given constant acceleration
+    pub fn update(self, a: &Vector<Acceleration>, t: f32) -> Vector<Velocity> {
+        // vx + ax t
+        Vector::<Velocity>::new(self.x + a.x * t, self.y + a.y * t)
     }
 }
 
-pub fn new_vel(v: &Velocity, a: &Acceleration, t: f32) -> Velocity {
-    // vx + ax t
-    Velocity {
-        x: v.x + a.x * t,
-        y: v.y + a.y * t,
+impl Vector<Acceleration> {
+    pub fn new(x: f32, y: f32) -> Self {
+        Vector::new_vec(Acceleration, x, y)
     }
 }

--- a/src/app/core/physics.rs
+++ b/src/app/core/physics.rs
@@ -36,7 +36,7 @@ impl Vector<Position> {
 
     // position after t seconds given constant acceleration
     pub fn update(
-        self,
+        &self,
         v: &Vector<Velocity>,
         a: &Vector<Acceleration>,
         t: f32,
@@ -47,6 +47,12 @@ impl Vector<Position> {
             self.y + v.y * t + 0.5 * a.x * t.powi(2),
         )
     }
+
+    pub fn update_const_v(&self, v: &Vector<Velocity>, t: f32) -> Vector<Position> {
+        let zero_a = Vector::<Acceleration>::default();
+
+        self.update(v, &zero_a, t)
+    }
 }
 
 impl Vector<Velocity> {
@@ -55,7 +61,7 @@ impl Vector<Velocity> {
     }
 
     // velocity update after t seconds given constant acceleration
-    pub fn update(self, a: &Vector<Acceleration>, t: f32) -> Vector<Velocity> {
+    pub fn update(&self, a: &Vector<Acceleration>, t: f32) -> Vector<Velocity> {
         // vx + ax t
         Vector::<Velocity>::new(self.x + a.x * t, self.y + a.y * t)
     }

--- a/src/app/core/physics.rs
+++ b/src/app/core/physics.rs
@@ -9,23 +9,31 @@ pub struct Velocity;
 pub struct Acceleration;
 // type VecType = Position | Velocity | Acceleration;
 
+pub trait VectorType {}
+impl VectorType for Position {}
+impl VectorType for Velocity {}
+impl VectorType for Acceleration {}
+
 #[derive(Clone, Debug, Default)]
-pub struct Vector<T> {
-    vec_type: T,
+pub struct Vector<T: VectorType> {
+    _type: T,
     pub x: f32,
     pub y: f32,
 }
-// TODO define trait VectorType, then do <T: VectorType> to restrict <T> to be only the valid vector types
 
 // TODO do this
 // pub type P = Vector<Position>;
 
-impl<T> Vector<T> {
+impl<T: VectorType> Vector<T> {
     pub fn mag(&self) -> f32 {
         (self.x.powi(2) + self.y.powi(2)).sqrt()
     }
     fn new_vec(vec_type: T, x: f32, y: f32) -> Self {
-        Self { vec_type, x, y }
+        Self {
+            _type: vec_type,
+            x,
+            y,
+        }
     }
 }
 

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -1,6 +1,6 @@
 pub mod core;
 pub mod orbital;
-// pub mod simple;
+pub mod simple;
 use femtovg::{renderer::WGPURenderer, Canvas};
 
 pub trait App {

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -1,6 +1,6 @@
 pub mod core;
 pub mod orbital;
-pub mod simple;
+// pub mod simple;
 use femtovg::{renderer::WGPURenderer, Canvas};
 
 pub trait App {

--- a/src/app/orbital/mod.rs
+++ b/src/app/orbital/mod.rs
@@ -235,14 +235,10 @@ impl Orbital {
         // println!("{:?}", cur_a);
 
         // v(t + dt) = v(t) + a(t)*dt
-        let next_v =
-            Vector::<Velocity>::new(self.outer.v.x + cur_a.x * dt, self.outer.v.y + cur_a.y * dt);
+        let next_v = self.outer.v.update(&cur_a, dt);
 
         // r(t + dt) = r(t) + v(t)*dt
-        let next_r = Vector::<Position>::new(
-            self.outer.pos.x + self.outer.v.x * dt,
-            self.outer.pos.y + self.outer.v.y * dt,
-        );
+        let next_r = self.outer.pos.update_const_v(&self.outer.v, dt);
 
         if next_r.mag() <= self.central.radius {
             self.stopped = true;

--- a/src/app/orbital/mod.rs
+++ b/src/app/orbital/mod.rs
@@ -231,23 +231,18 @@ impl Orbital {
         let a_y = -G_KM * self.central.mass * r.y / r.mag().powi(3); // m/s^2
         let a_y_km = a_y * 1e-3; // km/s^2
 
-        let cur_a = Acceleration {
-            x: a_x_km,
-            y: a_y_km,
-        };
+        let cur_a = Vector::<Acceleration>::new(a_x_km, a_y_km);
         // println!("{:?}", cur_a);
 
         // v(t + dt) = v(t) + a(t)*dt
-        let next_v = Velocity {
-            x: self.outer.v.x + cur_a.x * dt,
-            y: self.outer.v.y + cur_a.y * dt,
-        };
+        let next_v =
+            Vector::<Velocity>::new(self.outer.v.x + cur_a.x * dt, self.outer.v.y + cur_a.y * dt);
 
         // r(t + dt) = r(t) + v(t)*dt
-        let next_r = Position {
-            x: self.outer.pos.x + self.outer.v.x * dt,
-            y: self.outer.pos.y + self.outer.v.y * dt,
-        };
+        let next_r = Vector::<Position>::new(
+            self.outer.pos.x + self.outer.v.x * dt,
+            self.outer.pos.y + self.outer.v.y * dt,
+        );
 
         if next_r.mag() <= self.central.radius {
             self.stopped = true;
@@ -276,9 +271,9 @@ impl Orbital {
 
 #[derive(Default, Clone)]
 struct Body {
-    pos: Position,
-    v: Velocity,
-    _a: Acceleration,
+    pos: Vector<Position>,
+    v: Vector<Velocity>,
+    // _a: Acceleration,
     mass: f32,
     radius: f32,
 }
@@ -290,19 +285,19 @@ impl Body {
     fn outer_low() -> Self {
         Self {
             mass: 400000., // kg
-            pos: Position {
-                x: 0.,
-                y: 400. + 6378., // km, radius of earth = 6378
-            },
-            v: Velocity { x: 7.8, y: 0. }, // km/s
+            pos: Vector::<Position>::new(
+                0.,
+                400. + 6378., // km, radius of earth = 6378
+            ),
+            v: Vector::<Velocity>::new(7.8, 0.), // km/s
             ..Default::default()
         }
     }
     fn _outer_med() -> Self {
         Self {
             mass: 5000.,
-            pos: Position { x: 0., y: 20000. },
-            v: Velocity { x: 3.9, y: 0. },
+            pos: Vector::<Position>::new(0., 20000.),
+            v: Vector::<Velocity>::new(3.9, 0.),
             ..Default::default()
         }
     }
@@ -323,9 +318,6 @@ impl UiState {
     }
 }
 
-fn convert_pos_to_canvas(pos: &Position) -> Position {
-    Position {
-        x: pos.x,
-        y: -pos.y,
-    }
+fn convert_pos_to_canvas(pos: &Vector<Position>) -> Vector<Position> {
+    Vector::<Position>::new(pos.x, -pos.y)
 }

--- a/src/app/orbital/mod.rs
+++ b/src/app/orbital/mod.rs
@@ -5,7 +5,7 @@ use crate::ui::widgets::{CustomSlider, XYInput};
 use super::{
     core::{
         draw::scaled_width,
-        physics::{Acceleration, Position, Vector, Velocity, G_KM},
+        physics::{Acceleration, Position, Velocity, G_KM},
     },
     App,
 };
@@ -231,8 +231,7 @@ impl Orbital {
         let a_y = -G_KM * self.central.mass * r.y / r.mag().powi(3); // m/s^2
         let a_y_km = a_y * 1e-3; // km/s^2
 
-        let cur_a = Vector::<Acceleration>::new(a_x_km, a_y_km);
-        // println!("{:?}", cur_a);
+        let cur_a = Acceleration::new(a_x_km, a_y_km);
 
         // v(t + dt) = v(t) + a(t)*dt
         let next_v = self.outer.v.update(&cur_a, dt);
@@ -267,9 +266,8 @@ impl Orbital {
 
 #[derive(Default, Clone)]
 struct Body {
-    pos: Vector<Position>,
-    v: Vector<Velocity>,
-    // _a: Acceleration,
+    pos: Position,
+    v: Velocity,
     mass: f32,
     radius: f32,
 }
@@ -281,19 +279,19 @@ impl Body {
     fn outer_low() -> Self {
         Self {
             mass: 400000., // kg
-            pos: Vector::<Position>::new(
+            pos: Position::new(
                 0.,
                 400. + 6378., // km, radius of earth = 6378
             ),
-            v: Vector::<Velocity>::new(7.8, 0.), // km/s
+            v: Velocity::new(7.8, 0.), // km/s
             ..Default::default()
         }
     }
     fn _outer_med() -> Self {
         Self {
             mass: 5000.,
-            pos: Vector::<Position>::new(0., 20000.),
-            v: Vector::<Velocity>::new(3.9, 0.),
+            pos: Position::new(0., 20000.),
+            v: Velocity::new(3.9, 0.),
             ..Default::default()
         }
     }
@@ -314,6 +312,6 @@ impl UiState {
     }
 }
 
-fn convert_pos_to_canvas(pos: &Vector<Position>) -> Vector<Position> {
-    Vector::<Position>::new(pos.x, -pos.y)
+fn convert_pos_to_canvas(pos: &Position) -> Position {
+    Position::new(pos.x, -pos.y)
 }

--- a/src/app/simple/mod.rs
+++ b/src/app/simple/mod.rs
@@ -3,7 +3,7 @@ use femtovg::{renderer::WGPURenderer, Canvas, Color, Paint, Path};
 use super::{
     core::{
         eq_tolerance, midpoint,
-        physics::{Acceleration, Position, Vector, Velocity},
+        physics::{Acceleration, Position, Velocity},
     },
     App,
 };
@@ -11,9 +11,9 @@ use super::{
 pub struct ConstAcceleration {
     pub ui_state: UiState,
     started: bool,
-    hist: Vec<Vector<Position>>,
-    v: Vector<Velocity>,
-    a: Vector<Acceleration>,
+    hist: Vec<Position>,
+    v: Velocity,
+    a: Acceleration,
     t_per_tick: f32,
 }
 impl App for ConstAcceleration {
@@ -111,8 +111,8 @@ impl ConstAcceleration {
             ui_state: UiState::default(),
             started: false,
             hist: vec![],
-            v: Vector::<Velocity>::new(0., 0.),
-            a: Vector::<Acceleration>::new(0., -9.8),
+            v: Velocity::new(0., 0.),
+            a: Acceleration::new(0., -9.8),
             t_per_tick: 0.25,
         }
     }
@@ -174,20 +174,20 @@ impl ConstAcceleration {
     }
 
     pub fn start(&mut self) {
-        let start_pos = Vector::<Position>::new(self.ui_state.start_pos as f32, 0.);
+        let start_pos = Position::new(self.ui_state.start_pos as f32, 0.);
         self.hist = vec![start_pos];
         self.started = true;
 
-        self.a = Vector::<Acceleration>::new(self.a.x, self.a.y + self.ui_state.accel);
-        self.v = Vector::<Velocity>::new(self.ui_state.vx, self.ui_state.vy)
+        self.a = Acceleration::new(self.a.x, self.a.y + self.ui_state.accel);
+        self.v = Velocity::new(self.ui_state.vx, self.ui_state.vy)
     }
 
-    fn current_pos(&self) -> &Vector<Position> {
+    fn current_pos(&self) -> &Position {
         let index = self.hist.len() - 1;
         &self.hist[index]
     }
 }
 
-fn convert_pos_to_canvas(pos: &Vector<Position>) -> Vector<Position> {
-    Vector::<Position>::new(pos.x, -pos.y)
+fn convert_pos_to_canvas(pos: &Position) -> Position {
+    Position::new(pos.x, -pos.y)
 }

--- a/src/app/simple/mod.rs
+++ b/src/app/simple/mod.rs
@@ -3,7 +3,7 @@ use femtovg::{renderer::WGPURenderer, Canvas, Color, Paint, Path};
 use super::{
     core::{
         eq_tolerance, midpoint,
-        physics::{new_position, new_vel, Acceleration, Position, Velocity},
+        physics::{Acceleration, Position, Vector, Velocity},
     },
     App,
 };
@@ -11,17 +11,17 @@ use super::{
 pub struct ConstAcceleration {
     pub ui_state: UiState,
     started: bool,
-    hist: Vec<Position>,
-    v: Velocity,
-    a: Acceleration,
+    hist: Vec<Vector<Position>>,
+    v: Vector<Velocity>,
+    a: Vector<Acceleration>,
     t_per_tick: f32,
 }
 impl App for ConstAcceleration {
     fn run(&mut self) {
         if self.started {
-            while self.hist.len() < 500 && self.current().y >= 0. {
-                let new_pos = new_position(self.current(), &self.v, &self.a, self.t_per_tick);
-                let new_vel = new_vel(&self.v, &self.a, self.t_per_tick);
+            while self.hist.len() < 500 && self.current_pos().y >= 0. {
+                let new_pos = self.current_pos().update(&self.v, &self.a, self.t_per_tick);
+                let new_vel = self.v.update(&self.a, self.t_per_tick);
 
                 self.hist.push(new_pos);
                 self.v = new_vel;
@@ -111,18 +111,18 @@ impl ConstAcceleration {
             ui_state: UiState::default(),
             started: false,
             hist: vec![],
-            v: Velocity { x: 0., y: 0. },
-            a: Acceleration { x: 0., y: -9.8 },
+            v: Vector::<Velocity>::new(0., 0.),
+            a: Vector::<Acceleration>::new(0., -9.8),
             t_per_tick: 0.25,
         }
     }
 
     fn analyze(&self) {
-        if self.current().y <= 0. {
+        if self.current_pos().y <= 0. {
             println!(
                 "final pos: x: {}, y: {}",
-                self.current().x,
-                self.current().y
+                self.current_pos().x,
+                self.current_pos().y
             );
             println!("final time: {}", self.hist.len() as f32 * self.t_per_tick);
             // 0 = p.y + v.y * t + 0.5 * a.y * t^2
@@ -138,7 +138,7 @@ impl ConstAcceleration {
         let v = &self.v;
         let a = &self.a;
         let overall_end_t = self.hist.len() as f32 * self.t_per_tick;
-        let overall_end_pos = self.current();
+        let overall_end_pos = self.current_pos();
 
         let mut end_t = overall_end_t;
         let mut start_t = end_t - self.t_per_tick;
@@ -149,7 +149,7 @@ impl ConstAcceleration {
 
             let mid_t = midpoint(start_t, end_t);
             let delta_t_from_end = mid_t - overall_end_t;
-            let mid_pos = new_position(overall_end_pos, v, a, delta_t_from_end);
+            let mid_pos = overall_end_pos.update(v, a, delta_t_from_end);
 
             println!(
                 "looping. start {}, end {}, mid {}, pos {}",
@@ -174,29 +174,20 @@ impl ConstAcceleration {
     }
 
     pub fn start(&mut self) {
-        let start_pos = Position::new(self.ui_state.start_pos as f32, 0.);
+        let start_pos = Vector::<Position>::new(self.ui_state.start_pos as f32, 0.);
         self.hist = vec![start_pos];
         self.started = true;
 
-        self.a = Acceleration {
-            x: self.a.x,
-            y: self.a.y + self.ui_state.accel,
-        };
-        self.v = Velocity {
-            x: self.ui_state.vx,
-            y: self.ui_state.vy,
-        }
+        self.a = Vector::<Acceleration>::new(self.a.x, self.a.y + self.ui_state.accel);
+        self.v = Vector::<Velocity>::new(self.ui_state.vx, self.ui_state.vy)
     }
 
-    fn current(&self) -> &Position {
+    fn current_pos(&self) -> &Vector<Position> {
         let index = self.hist.len() - 1;
         &self.hist[index]
     }
 }
 
-fn convert_pos_to_canvas(pos: &Position) -> Position {
-    Position {
-        x: pos.x,
-        y: -pos.y,
-    }
+fn convert_pos_to_canvas(pos: &Vector<Position>) -> Vector<Position> {
+    Vector::<Position>::new(pos.x, -pos.y)
 }


### PR DESCRIPTION
Refactoring use of types related to Vectors
- use a single Vector type to remove duplication of things like a magnitude calculation
- use a generic so the type signatures can ensure a specific vector type is used
- use the VectorType trait to restrict the Vector struct to the desired vector types